### PR TITLE
Mention self-hosted compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Summary of new features:
   default Idris 1 back end. (Also, optionally, Chicken Scheme and Racket can
   be used as targets).
 + Everything works faster :).
++ Self-hosted compiler allows compiling the compiler itself on any platform where Idris/Blodwen runs, e.g. compiling Blodwen directly in your browser.
 
 A significant change in the implementation is that there is an intermediate
 language `TTImp`, which is essentially a desugared Idris, and is cleanly


### PR DESCRIPTION
I'm not a 100% sure, but in principle self-hosting should allow compiling the compiler to all platforms that Idris compiles to, right?
IMO that would be a huge benefit, as you could compile the compiler to JS, JVM, ... and open the doors to many use-cases.