### PR TITLE
Improve notes for installing, and Makefile fur testing.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,38 @@
+# Installation
+
+Blodwen is built using Idris, and provides support for three default code generation targets: Chez, Chicken, and Racket.
+
+## Idris
+
+There are several sets of instructions on how to install Idris from source and binary.
+
++ [Official ipkg installer for macOS](http://www.idris-lang.org/pkgs/idris-current.pkg)
++ [Source build instructions from the Idris GitHub Wiki](https://github.com/idris-lang/Idris-dev/wiki/Installation-Instructions)
++ [Binary installation using Cabal from the Idris Manual](https://idris.readthedocs.io/en/latest/tutorial/starting.html)
+
+## Code Generation Targets
+
+
+### Chez
+
+Chez Scheme is available to build from source:
+
++ https://cisco.github.io/ChezScheme/
+
+Many popular package managers will provide a binary distribution for Chez.
+
+### Chicken
+
+Chicken scheme offers binary distributions (and source tar balls) from
+
++ https://code.call-cc.org/
+
+You can find chicken in many a package manager.
+
+After installing chicken scheme you may need to install the 'numbers' package.
+
+### Racket
+
+Racket is available from:
+
++ https://download.racket-lang.org/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX = ${HOME}/.blodwen
-export BLODWEN_PATH = ${CURDIR}/prelude/build
+export BLODWEN_PATH = ${CURDIR}/prelude/build:${CURDIR}/base/build
 export BLODWEN_DATA = ${CURDIR}/support
 
 .PHONY: ttimp blodwen prelude test base lib_clean

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blodwen
 This is a prototype implementation of Idris 2.
 
 It is intended to be mostly backwards compatible with Idris 1, with some minor
-exceptions. The most notable user visible differences, which might cause 
+exceptions. The most notable user visible differences, which might cause
 Idris 1 programs to fail to type check, are:
 
 + Unbound implicit arguments are always erased, so it is a type error to
@@ -29,7 +29,7 @@ Summary of new features:
   annotation of erased types, and linear types.
 + `let` bindings are now more expressive, and can be used to define pattern
   matching functions locally.
-+ Names which are in scope in a type are also always in scope in the body of 
++ Names which are in scope in a type are also always in scope in the body of
   the corresponding definition.
 + Better inference. Holes are global to a source file, rather than local to
   a definition, meaning that some holes can be left in function types to be
@@ -72,6 +72,8 @@ I make no promises how well this works yet, but you are welcome to have a
 play. Good luck :).
 
 (Why "Blodwen"? The answer is here: http://ivortheengine.wikia.com/wiki/Idris)
+
+Information about external dependencies are presented in [Install.md](Install.md).
 
 Things still missing
 ====================

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -23,16 +23,16 @@ firstExists [] = pure Nothing
 firstExists (x :: xs) = if !(exists x) then pure (Just x) else firstExists xs
 
 findChez : IO String
-findChez 
+findChez
     = do e <- firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
-                                    x <- ["scheme", "chez"]]
+                                    x <- ["scheme", "chez", "chezscheme9.5"]]
          maybe (pure "/usr/bin/env scheme") pure e
 
 findLibs : List String -> List String
 findLibs = mapMaybe (isLib . trim)
   where
     isLib : String -> Maybe String
-    isLib d 
+    isLib d
         = if isPrefixOf "lib" d
              then Just (trim (substr 3 (length d) d))
              else Nothing
@@ -50,13 +50,13 @@ schHeader chez libs
 
 schFooter : String
 schFooter = ")"
-  
+
 mutual
   tySpec : CExp vars -> Core annot String
   tySpec (CPrimVal IntType) = pure "int"
   tySpec (CPrimVal StringType) = pure "string"
   tySpec (CPrimVal DoubleType) = pure "double"
-  tySpec (CCon (NS _ n) _ []) 
+  tySpec (CCon (NS _ n) _ [])
      = cond [(n == UN "Unit", pure "void"),
              (n == UN "Ptr", pure "void*")]
           (throw (InternalError ("Can't pass argument of type " ++ show n ++ " to foreign function")))
@@ -83,9 +83,9 @@ mutual
   chezExtPrim vs CCall [ret, fn, args, world]
       = pure "(error \"bad ffi call\")"
       -- throw (InternalError ("C FFI calls must be to statically known functions (" ++ show fn ++ ")"))
-  chezExtPrim vs GetStr [world] 
+  chezExtPrim vs GetStr [world]
       = pure $ mkWorld "(get-line (current-input-port))"
-  chezExtPrim vs prim args 
+  chezExtPrim vs prim args
       = schExtCommon chezExtPrim vs prim args
 
 compileToSS : Ref Ctxt Defs ->
@@ -126,4 +126,3 @@ executeExpr c tm
 export
 codegenChez : Codegen annot
 codegenChez = MkCG compileExpr executeExpr
-


### PR DESCRIPTION
When getting blodwen to install on my machine, I encountered hidden state and assumptions.

1. Chez scheme is not called `scheme` or `chez` on all platforms.
2. Let's give details on where to find more information about Blodwen's dependencies.
3. Chicken requires numbers.
4. Testing requires an installed blodwen.

Cherry pick as you see fit on this.