### PR TITLE
Abstract over FFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,15 @@ tramp
 /ttimp
 /runtests
 /src/BlodwenPaths.idr
+/src/CompilerRuntime.idr
 /tests/**/output
 /*/build/
+
+*.iml
+ttimpjvm
+blodwenjvmout
+ttimpjvmout
+
+*.class
+*.jar
+build

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,31 @@
 PREFIX = ${HOME}/.blodwen
 export BLODWEN_PATH = ${CURDIR}/prelude/build:${CURDIR}/base/build
 export BLODWEN_DATA = ${CURDIR}/support
+PLATFORM =
+BLODWEN = ../blodwen$(PLATFORM)
+COMPILER_PLATFORM := $(if $(PLATFORM),$(PLATFORM),c)
 
-.PHONY: ttimp blodwen prelude test base clean lib_clean
+.PHONY: ttimp blodwen prelude test base clean lib_clean src/CompilerRuntime.idr
 
 all: ttimp blodwen prelude base test
 
-ttimp:
-	idris --build ttimp.ipkg
+ttimp: src/CompilerRuntime.idr
+	idris --build ttimp$(PLATFORM).ipkg
 
-blodwen: src/BlodwenPaths.idr
-	idris --build blodwen.ipkg
+blodwen: src/BlodwenPaths.idr src/CompilerRuntime.idr
+	idris --build blodwen$(PLATFORM).ipkg
+
+src/CompilerRuntime.idr:
+	cp src/CompilerRuntime.$(COMPILER_PLATFORM).idr src/CompilerRuntime.idr
 
 src/BlodwenPaths.idr:
 	echo 'module BlodwenPaths; export bprefix : String; bprefix = "${PREFIX}"' > src/BlodwenPaths.idr
 
 prelude:
-	make -C prelude BLODWEN=../blodwen
+	make -C prelude BLODWEN=$(BLODWEN)
 
 base: prelude
-	make -C base BLODWEN=../blodwen
+	make -C base BLODWEN=$(BLODWEN)
 
 libs : prelude base
 
@@ -43,8 +49,8 @@ install:
 	mkdir -p ${PREFIX}/blodwen/support/chez
 	mkdir -p ${PREFIX}/blodwen/support/chicken
 	mkdir -p ${PREFIX}/blodwen/support/racket
-	make -C prelude install BLODWEN=../blodwen
-	make -C base install BLODWEN=../blodwen
+	make -C prelude install BLODWEN=$(BLODWEN)
+	make -C base install BLODWEN=$(BLODWEN)
 
 	install blodwen ${PREFIX}/bin
 	install support/chez/* ${PREFIX}/blodwen/support/chez

--- a/blodwenjvm
+++ b/blodwenjvm
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+BASEDIR=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  Darwin*) darwin=true
+           if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+		   if [ -z "$JAVA_HOME" ]; then
+		      if [ -x "/usr/libexec/java_home" ]; then
+			      JAVA_HOME=`/usr/libexec/java_home`
+			  else
+			      JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+			  fi
+           fi
+           ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+# If a specific java binary isn't specified search for the standard 'java' binary
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java`
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." 1>&2
+  echo "  We cannot execute $JAVACMD" 1>&2
+  exit 1
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
+  [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
+fi
+
+exec "$JAVACMD" $JAVA_OPTS  \
+  -Xss8m \
+  -Dapp.name="blodwenjvm" \
+  -Dapp.pid="$$" \
+  -Dapp.home="$BASEDIR" \
+  -Dbasedir="$BASEDIR" \
+  -cp \
+  $BASEDIR/Blodwen/blodwenjvmout:$IDRIS_JVM_HOME/idris-jvm-runtime.jar \
+  main.Main \
+  "$@"

--- a/blodwenjvm.ipkg
+++ b/blodwenjvm.ipkg
@@ -1,0 +1,37 @@
+package blodwen
+
+modules = Idris.CommandLine,
+          Idris.Desugar,
+          Idris.Error,
+          Idris.ModTree,
+          Idris.SetOptions,
+          Idris.Syntax,
+          Idris.Package,
+          Idris.Parser,
+          Idris.ProcessIdr,
+          Idris.REPL,
+          Idris.REPLCommon,
+          Idris.REPLOpts,
+          Idris.Resugar,
+
+          Idris.Elab.Implementation,
+          Idris.Elab.Interface,
+          Idris.Elab.Record,
+
+          Idris.IDEMode.CaseSplit,
+          Idris.IDEMode.Commands,
+          Idris.IDEMode.MakeClause,
+          Idris.IDEMode.Parser,
+          Idris.IDEMode.REPL,
+          Idris.IDEMode.TokenLine
+
+sourcedir = src
+
+executable = blodwenjvmout
+
+opts = "--partial-eval --portable-codegen jvm"
+
+pkgs = idrisjvmffi
+
+main = Idris.Main
+

--- a/manifest.mf
+++ b/manifest.mf
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: main.Main
+

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -9,7 +9,7 @@ import Core.TT
 import Data.CMap
 import Data.CSet
 
-%include C "sys/stat.h"
+import CompilerRuntime
     
 public export
 record Codegen annot where
@@ -88,7 +88,7 @@ findUsedNames tm
 -- Some things missing from Prelude.File
 
 export
-exists : String -> IO Bool
+exists : String -> BIO Bool
 exists f 
     = do Right ok <- openFile f Read
              | Left err => pure False
@@ -96,10 +96,5 @@ exists f
          pure True
 
 export
-tmpName : IO String
-tmpName = foreign FFI_C "tmpnam" (Ptr -> IO String) null
-
-export
-chmod : String -> Int -> IO ()
-chmod f m = foreign FFI_C "chmod" (String -> Int -> IO ()) f m
-
+tmpName : BIO String
+tmpName = tmpFileName

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -17,14 +17,16 @@ import Data.Vect
 import System
 import System.Info
 
+import CompilerRuntime
+
 %default covering
 
-firstExists : List String -> IO (Maybe String)
+firstExists : List String -> BIO (Maybe String)
 firstExists [] = pure Nothing
 firstExists (x :: xs) = if !(exists x) then pure (Just x) else firstExists xs
 
-findChez : IO String
-findChez
+findChez : BIO String
+findChez 
     = do e <- firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
                                     x <- ["scheme", "chez", "chezscheme9.5"]]
          maybe (pure "/usr/bin/env scheme") pure e

--- a/src/Compiler/Scheme/Chicken.idr
+++ b/src/Compiler/Scheme/Chicken.idr
@@ -17,16 +17,18 @@ import Data.Vect
 import System
 import System.Info
 
+import CompilerRuntime
+
 %default covering
 
-firstExists : List String -> IO (Maybe String)
+firstExists : List String -> BIO (Maybe String)
 firstExists [] = pure Nothing
 firstExists (x :: xs) = if !(exists x) then pure (Just x) else firstExists xs
 
-findCSI : IO String
+findCSI : BIO String
 findCSI = pure "/usr/bin/env csi"
 
-findCSC : IO String
+findCSC : BIO String
 findCSC = pure "/usr/bin/env csc"
 
 schHeader : List String -> String

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -16,16 +16,18 @@ import Data.Vect
 import System
 import System.Info
 
+import CompilerRuntime
+
 %default covering
 
-firstExists : List String -> IO (Maybe String)
+firstExists : List String -> BIO (Maybe String)
 firstExists [] = pure Nothing
 firstExists (x :: xs) = if !(exists x) then pure (Just x) else firstExists xs
 
-findRacket : IO String
+findRacket : BIO String
 findRacket = pure "/usr/bin/env racket"
 
-findRacoExe : IO String
+findRacoExe : BIO String
 findRacoExe = pure "raco exe"
 
 schHeader : String

--- a/src/CompilerRuntime.c.idr
+++ b/src/CompilerRuntime.c.idr
@@ -1,0 +1,68 @@
+module CompilerRuntime
+
+import public Control.IOExcept
+import public IO
+import public Prelude.File
+import public System
+import public Data.Buffer
+import public Data.IORef
+
+public export
+BIO : Type -> Type
+BIO = IO
+
+public export
+BIORef : Type -> Type
+BIORef = IORef
+
+public export
+bChangeDir : String -> BIO Bool
+bChangeDir = Prelude.File.changeDir
+
+public export
+bPrintLn : Show ty => ty -> BIO ()
+bPrintLn = Prelude.Interactive.printLn
+
+public export
+bPutChar : Char -> BIO () 
+bPutChar = Prelude.Interactive.putChar
+
+public export
+bGetChar : BIO Char
+bGetChar = Prelude.Interactive.getChar
+
+public export
+BIOExcept : Type -> Type -> Type
+BIOExcept = IOExcept' FFI_C
+
+public export
+BFile : Type
+BFile = Prelude.File.File
+
+public export
+BFileError : Type
+BFileError = Prelude.File.FileError
+
+public export
+cannotOpenFile : String -> BFileError
+cannotOpenFile fn = GenericFileError 0
+
+public export
+bOpenFile : (f : String) -> (m : Mode) -> BIO (Either BFileError File)
+bOpenFile = Prelude.File.openFile
+
+public export
+bReadFile : String -> BIO (Either BFileError String)
+bReadFile = Prelude.File.readFile
+
+public export
+chmod : String -> Int -> IO ()	
+chmod f m = foreign FFI_C "chmod" (String -> Int -> IO ()) f m
+
+public export
+tmpFileName : BIO String
+tmpFileName = foreign FFI_C "tmpnam" (Ptr -> IO String) null
+
+public export
+hexNum : Int -> BIO ()
+hexNum num = foreign FFI_C "printf" (String -> Int -> IO ()) "%06x" num

--- a/src/CompilerRuntime.jvm.idr
+++ b/src/CompilerRuntime.jvm.idr
@@ -1,0 +1,71 @@
+module CompilerRuntime
+
+import Java.Lang
+import public Control.IOExcept
+import public IdrisJvm.IO
+import public IdrisJvm.File
+import public IdrisJvm.System
+import public IdrisJvm.Data.Buffer
+import public Data.IORef
+
+public export
+BIO : Type -> Type
+BIO = JVM_IO
+
+public export
+BIORef : Type -> Type
+BIORef = IdrisJvm.FFI.IORef
+
+public export
+BIOExcept : Type -> Type -> Type
+BIOExcept = IOExcept' FFI_JVM
+
+public export
+tmpFileName : BIO String
+tmpFileName = getTemporaryFileName
+
+public export
+hexNum : Int -> BIO ()
+hexNum num = print $ JavaString.format "%06x" !(listToArray [the Object $ believe_me $ JInteger.valueOf num])
+
+
+
+public export
+bChangeDir : String -> BIO Bool
+bChangeDir = IdrisJvm.File.changeDir
+
+public export
+bPrintLn : Show ty => ty -> BIO ()
+bPrintLn = IdrisJvm.IO.printLn
+
+public export
+bPutChar : Char -> BIO () 
+bPutChar = IdrisJvm.IO.putChar
+
+public export
+bGetChar : BIO Char
+bGetChar = IdrisJvm.IO.getChar
+
+public export
+BFile : Type
+BFile = IdrisJvm.File.File
+
+public export
+BFileError : Type
+BFileError = IdrisJvm.File.FileError
+
+public export
+cannotOpenFile : String -> BFileError
+cannotOpenFile fn = believe_me (unableToReadFile fn)
+
+public export
+bOpenFile : (f : String) -> (m : Mode) -> BIO (Either BFileError File)
+bOpenFile = IdrisJvm.File.openFile
+
+public export
+bReadFile : String -> BIO (Either BFileError String)
+bReadFile = IdrisJvm.File.readFile
+
+public export
+chmod : String -> Int -> BIO ()
+chmod = IdrisJvm.File.chmod

--- a/src/Control/Monad/StateE.idr
+++ b/src/Control/Monad/StateE.idr
@@ -5,7 +5,8 @@
 module Control.Monad.StateE
 
 import public Control.Catchable
-import public Control.IOExcept
+
+import CompilerRuntime
 
 %default total
 
@@ -240,18 +241,18 @@ interface ConsoleIO (m : Type -> Type) where
   getChar : SE s err m Char
 
 export 
-ConsoleIO IO where
+ConsoleIO BIO where
   putStr = lift . putStr
   getStr = lift getLine
-  putChar = lift . putChar
-  getChar = lift getChar
+  putChar = lift . bPutChar
+  getChar = lift bGetChar
 
 export 
-ConsoleIO (IOExcept err) where
+ConsoleIO (BIOExcept err) where
   putStr str = lift (ioe_lift (putStr str))
   getStr = lift (ioe_lift getLine)
-  putChar c = lift (ioe_lift (putChar c))
-  getChar = lift (ioe_lift getChar)
+  putChar c = lift (ioe_lift (bPutChar c))
+  getChar = lift (ioe_lift bGetChar)
 
 export
 putStrLn : ConsoleIO m => String -> SE ss err m ()

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -16,7 +16,7 @@ import Core.UnifyState
 
 import public Utils.Binary
 
-import Data.Buffer
+import CompilerRuntime
 
 %default covering
 

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -17,6 +17,8 @@ import Data.StringMap
 import Data.CSet
 import Data.List
 
+import CompilerRuntime
+
 %default total
 
 public export
@@ -970,7 +972,7 @@ export
 setWorkingDir : {auto c : Ref Ctxt Defs} -> String -> Core annot ()
 setWorkingDir dir
     = do defs <- get Ctxt
-         coreLift $ changeDir dir
+         coreLift $ bChangeDir dir
          cdir <- coreLift $ currentDir
          put Ctxt (record { options->dirs->working_dir = cdir } defs)
 
@@ -1486,9 +1488,9 @@ setDetermining loc tn args
                            ++ showSep ", " (map show ns)))
 
 export
-runWithCtxt : Show annot => Core annot () -> IO ()
+runWithCtxt : Show annot => Core annot () -> BIO ()
 runWithCtxt prog = coreRun prog 
-                           (\err => printLn err)
+                           (\err => bPrintLn err)
                            (\ok => pure ())
 
 -- Return whether an argument to the given term would be a forced argument

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -5,7 +5,7 @@ import Core.CaseTree
 import Parser.Support
 
 import public Control.Catchable
-import public Data.IORef
+import public CompilerRuntime
 
 %default covering
 
@@ -288,11 +288,11 @@ getAnnot (InRHS x y err) = getAnnot err
 export
 record Core annot t where
   constructor MkCore
-  runCore : IO (Either (Error annot) t)
+  runCore : BIO (Either (Error annot) t)
 
 export
-coreRun : Core annot a -> 
-          (Error annot -> IO b) -> (a -> IO b) -> IO b
+coreRun : Core annot a ->
+          (Error annot -> BIO b) -> (a -> BIO b) -> BIO b
 coreRun (MkCore act) err ok = either err ok !act
 
 export
@@ -310,7 +310,7 @@ wrapError fe (MkCore prog)
 -- This would be better if we restrict it to a limited set of IO operations
 export
 %inline
-coreLift : IO a -> Core annot a
+coreLift : BIO a -> Core annot a
 coreLift op = MkCore $ map Right op
 
 {- Monad, Applicative, Traversable are specialised by hand for Core.
@@ -366,7 +366,7 @@ traverse f xs = traverse' f xs []
 
 export
 data Ref : label -> Type -> Type where
-	   MkRef : IORef a -> Ref x a
+	   MkRef : BIORef a -> Ref x a
 
 export
 newRef : (x : label) -> t -> Core annot (Ref x t)

--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -7,6 +7,8 @@ import Core.Name
 
 import System.Info
 
+import CompilerRuntime
+
 %default total
 
 isWindows : Bool
@@ -104,7 +106,7 @@ pathToNS wdir fname
 
 -- Create subdirectories, if they don't exist
 export
-mkdirs : List String -> IO (Either FileError ())
+mkdirs : List String -> BIO (Either FileError ())
 mkdirs [] = pure (Right ())
 mkdirs (d :: ds)
     = do ok <- changeDir d

--- a/src/Core/GetType.idr
+++ b/src/Core/GetType.idr
@@ -8,6 +8,7 @@ import Core.CaseTree
 import Data.List
 
 %default covering
+%hide Language.Reflection.Binder
 
 -- Get the type of an already typechecked thing.
 -- We need this (occasionally) because we don't store types in subterms (e.g. on

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -9,7 +9,11 @@ import Utils.Binary
 import Data.List
 import Data.Vect
 
+import CompilerRuntime
+
 %default total
+%hide Language.Reflection.NameType
+%hide Language.Reflection.Binder
 
 -- TTC instances for TT primitives
 

--- a/src/Core/Typecheck.idr
+++ b/src/Core/Typecheck.idr
@@ -9,6 +9,10 @@ import Data.List
 
 %default covering
 
+%hide Language.Reflection.Raw
+%hide Language.Reflection.Binder
+%hide FFI_C.Raw
+
 export
 doConvert : (Quote tm, Convert tm) => 
             annot -> Defs -> Env Term outer -> 

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -11,6 +11,8 @@ import Data.CSet
 import Data.List
 import Data.List.Views
 
+import CompilerRuntime
+
 %default covering
 
 public export

--- a/src/Data/IOHash.idr
+++ b/src/Data/IOHash.idr
@@ -2,6 +2,8 @@ module Data.IOHash
 
 import Data.IOArray
 
+import CompilerRuntime
+
 -- A simple implementation of a mutable hash table
 
 export
@@ -14,7 +16,7 @@ record IOHash key value where
 
 export
 new : (key -> key -> Bool) ->
-      (key -> Int) -> Nat -> IO (IOHash key valInt)
+      (key -> Int) -> Nat -> BIO (IOHash key valInt)
 new eq hash n
     = do arr <- newArray (cast n) []
          pure (MkTable eq hash (cast n) arr)
@@ -23,7 +25,7 @@ findPos : Int -> Int -> Int
 findPos hash x = assert_total $ if x <=0 then 0 else abs (hash `mod` x)
 
 export
-insert : key -> value -> IOHash key value -> IO ()
+insert : key -> value -> IOHash key value -> BIO ()
 insert k v table
     = do let arr = buckets table
          let pos = hash table k `findPos` numBuckets table
@@ -31,7 +33,7 @@ insert k v table
          unsafeWriteArray arr pos ((k, v) :: row)
 
 export
-update : key -> value -> IOHash key value -> IO ()
+update : key -> value -> IOHash key value -> BIO ()
 update k v table
     = do let arr = buckets table
          let pos = hash table k `findPos` numBuckets table
@@ -46,7 +48,7 @@ update k v table
                      else ((k', v') :: updateVal eq k v rest)
 
 export
-delete : key -> IOHash key value -> IO ()
+delete : key -> IOHash key value -> BIO ()
 delete k table
     = do let arr = buckets table
          let pos = hash table k `findPos` numBuckets table
@@ -60,7 +62,7 @@ delete k table
         = if eq k k' then rest else ((k', v') :: deleteVal eq k rest)
 
 export
-lookup : key -> IOHash key value -> IO (Maybe value)
+lookup : key -> IOHash key value -> BIO (Maybe value)
 lookup k table
     = do let arr = buckets table
          let pos = hash table k `findPos` numBuckets table

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -2,6 +2,8 @@ module Idris.CommandLine
 
 import Data.Vect
 
+import CompilerRuntime
+
 %default total
 
 public export
@@ -145,7 +147,7 @@ getOpts opts = parseOpts options opts
 
 
 export covering
-getCmdOpts : IO (Either String (List CLOpt))
+getCmdOpts : BIO (Either String (List CLOpt))
 getCmdOpts = do (_ :: opts) <- getArgs
                     | pure (Left "Invalid command line")
                 pure $ getOpts opts

--- a/src/Idris/IDEMode/Commands.idr
+++ b/src/Idris/IDEMode/Commands.idr
@@ -3,6 +3,8 @@ module Idris.IDEMode.Commands
 import Core.Core
 import Core.Name
 
+import CompilerRuntime
+
 %default covering
 
 public export
@@ -146,8 +148,8 @@ export
 version : Int -> Int -> SExp
 version maj min = toSExp (SymbolAtom "protocol-version", maj, min)
 
-hex : Int -> IO ()
-hex num = foreign FFI_C "printf" (String -> Int -> IO ()) "%06x" num
+hex : Int -> BIO ()
+hex num = hexNum num
 
 export
 send : SExpable a => a -> Core annot ()

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -33,9 +33,11 @@ import TTImp.ProcessTTImp
 import TTImp.Reflect
 
 import Control.Catchable
-import System
+-- import System
 
-getNChars : Nat -> IO (List Char)
+import CompilerRuntime
+
+getNChars : Nat -> BIO (List Char)
 getNChars Z = pure []
 getNChars (S k)
     = do x <- getChar
@@ -68,7 +70,7 @@ toHex m (d :: ds)
 
 -- Read 6 characters. If they're a hex number, read that many characters.
 -- Otherwise, just read to newline
-getInput : IO String
+getInput : BIO String
 getInput 
     = do x <- getNChars 6
          case toHex 1 (reverse x) of

--- a/src/Idris/Main.idr
+++ b/src/Idris/Main.idr
@@ -21,9 +21,11 @@ import Idris.SetOptions
 import Idris.Syntax
 
 import Data.Vect
-import System
+-- import System
 
 import BlodwenPaths
+
+import CompilerRuntime
 
 %default covering
 
@@ -125,7 +127,7 @@ stMain opts
 
 -- Run any options (such as --version or --help) which imply printing a
 -- message then exiting. Returns wheter the program should continue
-quitOpts : List CLOpt -> IO Bool
+quitOpts : List CLOpt -> BIO Bool
 quitOpts [] = pure True
 quitOpts (Version :: _)
     = do putStrLn versionMsg
@@ -138,7 +140,7 @@ quitOpts (ShowPrefix :: _)
          pure False
 quitOpts (_ :: opts) = quitOpts opts
 
-main : IO ()
+main : BIO ()
 main = do Right opts <- getCmdOpts
              | Left err =>
                     do putStrLn err

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -6,6 +6,8 @@ import Core.Directory
 import Core.Options
 import Core.Unify
 
+import Control.Catchable
+
 import Idris.CommandLine
 import Idris.ModTree
 import Idris.ProcessIdr
@@ -16,8 +18,10 @@ import Parser.Lexer
 import Parser.Support
 import Utils.Binary
 
-import System
+-- import System
 import Text.Parser
+
+import CompilerRuntime
 
 %default covering
 
@@ -182,7 +186,7 @@ build pkg
          runScript (postbuild pkg)
          pure []
 
-copyFile : String -> String -> IO (Either FileError ())
+copyFile : String -> String -> BIO (Either FileError ())
 copyFile src dest
     = do Right buf <- readFromFile src
              | Left err => pure (Left err)

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -39,7 +39,8 @@ import TTImp.Reflect
 
 import Control.Catchable
 
-import System
+-- import System
+import CompilerRuntime
 
 %default covering
 

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -10,7 +10,8 @@ import Idris.CommandLine
 import Idris.REPL
 import Idris.Syntax
 
-import System
+-- import System
+
 
 -- TODO: Version numbers on dependencies
 export

--- a/src/Interfaces/FileIO.idr
+++ b/src/Interfaces/FileIO.idr
@@ -1,8 +1,8 @@
 module Interfaces.FileIO
 
 import Control.Monad.StateE
-import Control.IOExcept
 import Core.Context
+import CompilerRuntime
 
 public export
 interface FileIO (m : Type -> Type) where
@@ -12,11 +12,12 @@ interface FileIO (m : Type -> Type) where
               SE s err m (Either FileError ())
 
 export
-FileIO IO where
+FileIO BIO where
   readFile f = lift (readFile f)
   writeFile f c = lift (writeFile f c)
 
 export
-FileIO (IOExcept (Error annot)) where
+FileIO (BIOExcept (Error annot)) where
+  -- not handling errors for now
   readFile f = lift (ioe_lift (readFile f))
   writeFile f c = lift (ioe_lift (writeFile f c))

--- a/src/Interfaces/SystemIO.idr
+++ b/src/Interfaces/SystemIO.idr
@@ -1,8 +1,9 @@
 module Interfaces.SystemIO
 
 import Control.Monad.StateE
-import Control.IOExcept
 import Core.Context
+
+import CompilerRuntime
 
 public export
 interface SystemIO (m : Type -> Type) where
@@ -13,5 +14,9 @@ SystemIO IO where
   getArgs = lift getArgs
 
 export
-SystemIO (IOExcept (Error annot)) where
+SystemIO BIO where
+  getArgs = lift getArgs
+
+export
+SystemIO (BIOExcept (Error annot)) where
   getArgs = lift (ioe_lift getArgs)

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -7,6 +7,8 @@ import public Text.Parser
 import Core.TT
 import Data.List.Views
 
+import CompilerRuntime
+
 %default total
 
 public export
@@ -20,7 +22,7 @@ EmptyRule ty = Grammar (TokenData Token) False ty
 public export
 data ParseError = ParseFail String (Maybe (Int, Int)) (List Token)
                 | LexFail (Int, Int, String)
-                | FileFail FileError
+                | FileFail BFileError
 
 export
 Show ParseError where
@@ -57,9 +59,9 @@ runParser str p
                    Right (val, _) => Right val
 
 export
-parseFile : (fn : String) -> Rule ty -> IO (Either ParseError ty)
+parseFile : (fn : String) -> Rule ty -> BIO (Either ParseError ty)
 parseFile fn p
-    = do Right str <- readFile fn
+    = do Right str <- bReadFile fn
              | Left err => pure (Left (FileFail err))
          pure (runParser str p)
 

--- a/src/TTImp/GenerateDef.idr
+++ b/src/TTImp/GenerateDef.idr
@@ -7,6 +7,8 @@ import Core.Metadata
 import Core.Normalise
 import Core.TT
 import Core.Unify
+import Control.Monad.StateE
+import Control.Catchable
 
 import TTImp.CaseSplit
 import TTImp.Elab

--- a/src/TTImp/Main.idr
+++ b/src/TTImp/Main.idr
@@ -21,6 +21,8 @@ import TTImp.TTImp
 
 import Parser.RawImp
 
+import CompilerRuntime
+
 usageMsg : Core () ()
 usageMsg = coreLift $ putStrLn "Usage: ttimp [source file]"
 
@@ -49,7 +51,7 @@ stMain
                             writeToTTC () !(getTTCFileName fname ".ttc")
          repl {c} {u} {m}
 
-main : IO ()
+main : BIO ()
 main = do putStrLn "Welcome to TTImp. Good luck."
           coreRun stMain
                (\err : Error () => putStrLn ("Uncaught error: " ++ show err))

--- a/src/TTImp/ProcessTTImp.idr
+++ b/src/TTImp/ProcessTTImp.idr
@@ -94,7 +94,7 @@ process : {auto c : Ref Ctxt Defs} ->
           {auto m : Ref Meta (Metadata ())} ->
           String -> Core () Bool
 process file
-    = do Right res <- coreLift (readFile file)
+    = do Right res <- coreLift (bReadFile file)
                | Left err => do coreLift (putStrLn ("File error: " ++ show err))
                                 pure False
          case runParser res (do p <- prog; eoi; pure p) of

--- a/src/Utils/Binary.idr
+++ b/src/Utils/Binary.idr
@@ -1,10 +1,10 @@
 module Utils.Binary
 
 import Core.Core
-import Data.Buffer
 import Data.List
 import Data.Vect
 import public Data.StringMap
+import CompilerRuntime
 
 -- Serialising data as binary. Provides an interface TTC which allows
 -- reading and writing to chunks of memory, "Binary", which can be written
@@ -49,7 +49,7 @@ incLoc i c = record { loc $= (+i) } c
 export
 data Binary = MkBin (List Chunk) Chunk (List Chunk)
 
-dumpBin : Binary -> IO ()
+dumpBin : Binary -> BIO ()
 dumpBin (MkBin done chunk rest)
    = do printLn !(traverse bufferData (map buf done))
         printLn !(bufferData (buf chunk))
@@ -76,7 +76,7 @@ req (c :: cs)
 -- Take all the data from the chunks in a 'Binary' and copy them into one
 -- single buffer, ready for writing to disk.
 -- TODO: YAGNI? Delete if so...
-toBuffer : Binary -> IO (Maybe Buffer)
+toBuffer : Binary -> BIO (Maybe Buffer)
 toBuffer (MkBin done cur rest)
     = do let chunks = reverse done ++ cur :: rest
          Just b <- newBuffer (req chunks)
@@ -84,42 +84,42 @@ toBuffer (MkBin done cur rest)
          copyToBuf 0 b chunks
          pure (Just b)
   where
-    copyToBuf : (pos : Int) -> Buffer -> List Chunk -> IO ()
+    copyToBuf : (pos : Int) -> Buffer -> List Chunk -> BIO ()
     copyToBuf pos b [] = pure ()
     copyToBuf pos b (c :: cs)
         = do copyData (buf c) 0 (used c) b pos
              copyToBuf (pos + used c) b cs
 
-fromBuffer : Buffer -> IO Binary
+fromBuffer : Buffer -> BIO Binary
 fromBuffer buf
     = do len <- rawSize buf
          pure (MkBin [] (MkChunk buf 0 len len) []) -- assume all used
 
 export
-writeToFile : (fname : String) -> Binary -> IO (Either FileError ())
+writeToFile : (fname : String) -> Binary -> BIO (Either BFileError ())
 writeToFile fname (MkBin done cur rest)
-    = do Right h <- openFile fname WriteTruncate
+    = do Right h <- bOpenFile fname WriteTruncate
                | Left err => pure (Left err)
          let chunks = reverse done ++ cur :: rest
          writeChunks h chunks
          closeFile h
          pure (Right ())
   where
-    writeChunks : File -> List Chunk -> IO ()
+    writeChunks : BFile -> List Chunk -> BIO ()
     writeChunks h [] = pure ()
     writeChunks h (c :: cs)
         = do writeBufferToFile h (resetBuffer (buf c)) (used c)
              writeChunks h cs
 
 export
-readFromFile : (fname : String) -> IO (Either FileError Binary)
+readFromFile : (fname : String) -> BIO (Either BFileError Binary)
 readFromFile fname
-    = do Right h <- openFile fname Read
+    = do Right h <- bOpenFile fname Read
                | Left err => pure (Left err)
          Right max <- fileSize h
                | Left err => pure (Left err)
          Just b <- newBuffer max
-               | Nothing => pure (Left (GenericFileError 0)) --- um, not really
+               | Nothing => pure (Left (cannotOpenFile fname)) --- um, not really
          b <- readBufferFromFile h b max
          pure (Right (MkBin [] (MkChunk b 0 max max) []))
 

--- a/ttimpjvm.ipkg
+++ b/ttimpjvm.ipkg
@@ -1,0 +1,99 @@
+package ttimp
+
+modules = Compiler.Common,
+          Compiler.CompileExpr,
+          Compiler.Scheme.Chez,
+          Compiler.Scheme.Chicken,
+          Compiler.Scheme.Common,
+          Compiler.Scheme.Racket,
+          Compiler.Inline,
+          
+          Control.Delayed,
+
+          Core.AutoSearch,
+          Core.Binary,
+          Core.CaseBuilder,
+          Core.CaseTree,
+          Core.CompileExpr,
+          Core.Context, 
+          Core.Core,
+          Core.Coverage,
+          Core.Directory,
+          Core.GetType,
+          Core.Hash,
+          Core.InitPrimitives,
+          Core.LinearCheck,
+          Core.Metadata,
+          Core.Name,
+          Core.Normalise,
+          Core.Options,
+          Core.Primitives,
+          Core.ProcessTT,
+          Core.Reflect,
+          Core.Termination,
+          Core.TT,
+          Core.TTC,
+          Core.Typecheck,
+          Core.Unify,
+          Core.UnifyState,
+
+          Control.Monad.StateE,
+
+          Data.Bool.Extra,
+          Data.CMap,
+          Data.CSet,
+          Data.StringMap,
+
+          Interfaces.FileIO,
+          Interfaces.SystemIO,
+
+          Parser.Lexer,
+          Parser.Raw,
+          Parser.RawImp,
+          Parser.REPL,
+          Parser.Support,
+
+          Text.Lexer,
+          Text.Lexer.Core,
+          Text.Parser,
+          Text.Parser.Core,
+          Text.Quantity,
+          Text.Token,
+
+          TTImp.BindImplicits,
+          TTImp.CaseSplit,
+          TTImp.Elab,
+          TTImp.Elab.Ambiguity,
+          TTImp.Elab.Case,
+          TTImp.Elab.Delayed,
+          TTImp.Elab.Record,
+          TTImp.Elab.Rewrite,
+          TTImp.Elab.State,
+          TTImp.Elab.Term,
+          TTImp.Elab.Unelab,
+          TTImp.ExprSearch,
+          TTImp.GenerateDef,
+          TTImp.MakeLemma,
+          TTImp.ProcessData,
+          TTImp.ProcessDef,
+          TTImp.ProcessRecord,
+          TTImp.ProcessType,
+          TTImp.ProcessTTImp,
+          TTImp.Reflect,
+          TTImp.REPL,
+          TTImp.RunElab,
+          TTImp.TTImp,
+          TTImp.Utils,
+
+          Utils.Binary
+
+sourcedir = src
+
+executable = ttimpjvmout
+
+opts = "--partial-eval --portable-codegen jvm"
+
+pkgs = idrisjvmffi
+
+main = TTImp.Main
+


### PR DESCRIPTION
Nothing to see here yet, but I'd like to use this PR as a starting point for discussion.
@mmhelloworld has achieved the amazing feat of getting Blodwen to compile on idris-jvm:
https://github.com/mmhelloworld/idris-jvm/issues/79
In order to do this, he had to make some changes to Blodwen itself:
https://github.com/mmhelloworld/Blodwen/commit/1de49a9c242410a102b7082fa25bbf65a8551be3
These changes modify the code to work with idris-jvm, but take away the possibility to compile using native Idris.
I've been reading up on how one could make this compatible with both C and JVM FFI. The recommended way seems to be algebraic effect types (see [section 4.4 here](https://eb.host.cs.st-andrews.ac.uk/drafts/compile-idris.pdf) and [the corresponding section in the official documentation](http://docs.idris-lang.org/en/latest/effects/impleff.html)).
I think I understand the basic principles, so this might be something where I could contribute.

@edwinb do you agree this is the right approach?
If so, I would give this a shot and start introducing algebras like `FileSystem` that can then be implemented by both C and JVM FFIs.