### PR TITLE
Fix non-exhaustive pattern

### DIFF
--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -67,6 +67,7 @@ addLHS loc outerenvlen env tm
     toPat : Env Term vs -> Env Term vs
     toPat (Lam c p ty :: bs) = PVar c ty :: toPat bs
     toPat (b :: bs) = b :: toPat bs
+    toPat [] = []
 
 export
 addNameType : {auto m : Ref Meta (Metadata annot)} ->


### PR DESCRIPTION
I encountered this while compiling Blodwen to JVM. I initially thought it was an issue with JVM back end code as the back end was returning `null` for non-exhaustive patterns. I have now fixed the JVM back end to throw errors in these cases. This change is needed to get Blodwen running on the JVM.