### PR TITLE
Add make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX = ${HOME}/.blodwen
 export BLODWEN_PATH = ${CURDIR}/prelude/build
 export BLODWEN_DATA = ${CURDIR}/support
 
-.PHONY: ttimp blodwen prelude test base lib_clean
+.PHONY: ttimp blodwen prelude test base clean lib_clean
 
 all: ttimp blodwen prelude base test
 
@@ -22,6 +22,13 @@ base: prelude
 	make -C base BLODWEN=../blodwen
 
 libs : prelude base
+
+clean: lib_clean
+	make -C src clean
+	make -C tests clean
+	rm -f blodwen
+	rm -f runtests
+	rm -f ttimp
 
 lib_clean:
 	make -C prelude clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,3 @@
+clean:
+	rm -f BlodwenPaths.idr
+	find . -name '*.ibc' | xargs rm -f

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,3 +4,6 @@ BLODWEN = ../../../blodwen
 test:
 	../runtests $(TTIMP) $(BLODWEN)
 
+clean:
+	find . -name '*.ibc' | xargs rm -f
+	find . -name 'output' | xargs rm -f


### PR DESCRIPTION
Repo needs to be properly cleaned when updating the Idris compiler.

After failing to build Blodwen with Idris 1.3.0, I realized I needed Idris 1.3.1 to be able to compile Blodwen. But the builds system couldn't handle that old ibc-files generated by version 1.3.0 were still present in the src folder. make lib_clean only cleans prelude and base, not Blodwen.
```
$ make

...

Incompatible ibc version for: "./Builtins.ibc"
This module was built with an earlier version of Idris.
Please clean and rebuild.

$ make lib_clean
$ make

...

Incompatible ibc version for: "./Data/CSet.ibc"
This module was built with an earlier version of Idris.
Please clean and rebuild.
```