### PR TITLE
Mention (current) lack of socket support in IDE mode

### DIFF
--- a/Notes/IDE-mode.md
+++ b/Notes/IDE-mode.md
@@ -41,3 +41,8 @@ declared with the given name, on the given line. It will only return the
 first definition it finds, as a list of pattern clauses. This works via a
 combination of case splitting and expression search.
 
+To-Do
+-------
+
+Currently the IDE protocol does not support socket mode. This will be advantageous 
+for integrating with [emacs idris-mode](https://github.com/idris-hackers/idris-mode/issues/489).


### PR DESCRIPTION
As discussed in the [idris-mode issues](https://github.com/idris-hackers/idris-mode/issues/489) socket support doesn't seem to be up and running yet.

I hope one of the discussants will be able to issue a PR porting socket-mode from Idris1 and removing this note in the near future.