### PR TITLE
Fixed inconsistency between REPL and -x for casting strings to nums

### DIFF
--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -10,12 +10,15 @@
 (define cast-num 
   (lambda (x) 
     (if (number? x) x 0)))
+(define destroy-prefix
+  (lambda (x)
+    (if (eqv? (string-ref x 0) #\#) "" x)))
 (define cast-string-int
   (lambda (x)
-    (floor (cast-num (string->number x)))))
+    (floor (cast-num (string->number (destroy-prefix x))))))
 (define cast-string-double
   (lambda (x)
-    (cast-num (string->number x))))
+    (cast-num (string->number (destroy-prefix x)))))
 (define string-cons (lambda (x y) (string-append (string x) y)))
 (define get-tag (lambda (x) (vector-ref x 0)))
 (define string-reverse (lambda (x)

--- a/support/chicken/support.scm
+++ b/support/chicken/support.scm
@@ -10,12 +10,15 @@
 (define cast-num 
   (lambda (x) 
     (if (number? x) x 0)))
+(define destroy-prefix
+  (lambda (x)
+    (if (eqv? (string-ref x 0) #\#) "" x)))
 (define cast-string-int
   (lambda (x)
-    (floor (cast-num (string->number x)))))
+    (floor (cast-num (string->number (destroy-prefix x))))))
 (define cast-string-double
   (lambda (x)
-    (cast-num (string->number x))))
+    (cast-num (string->number (destroy-prefix x)))))
 (define string-cons (lambda (x y) (string-append (string x) y)))
 (define get-tag (lambda (x) (vector-ref x 0)))
 (define string-reverse (lambda (x)

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -10,12 +10,15 @@
 (define cast-num 
   (lambda (x) 
     (if (number? x) x 0)))
+(define destroy-prefix
+  (lambda (x)
+    (if (eqv? (string-ref x 0) #\#) "" x)))
 (define cast-string-int
   (lambda (x)
-    (floor (cast-num (string->number x)))))
+    (floor (cast-num (string->number (destroy-prefix x))))))
 (define cast-string-double
   (lambda (x)
-    (cast-num (string->number x))))
+    (cast-num (string->number (destroy-prefix x)))))
 (define string-cons (lambda (x y) (string-append (string x) y)))
 (define get-tag (lambda (x) (vector-ref x 0)))
 (define string-reverse (lambda (x)


### PR DESCRIPTION
I happened to notice that the value of `the Integer $ cast "#x10"` differed between when you evaluated it with the REPL and when you ran it by putting it in a file and using the --exec / -x option. The former would give you 0 (from a parsing error) and the latter will give you 16. This 16 comes from the fact that in Scheme you can write numbers in hex by prepending #x to them.

To counter this problem I made the scheme backends now check if the string being passed in is using a prefix. If so, it will destroy the string so it is unable to parse it into a number matching the behavior of the REPL.