### PR TITLE
Add space after the string to keep consistent with Idris REPL.

### DIFF
--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -539,7 +539,7 @@ processCatch cmd
 
 parseRepl : String -> Either ParseError REPLCmd
 parseRepl inp
-    = case fnameCmd [(":load", Load), (":l", Load), (":cd", CD)] inp of
+    = case fnameCmd [(":load ", Load), (":l ", Load), (":cd ", CD)] inp of
            Nothing => runParser inp (do c <- command; eoi; pure c)
            Just cmd => Right cmd
   where


### PR DESCRIPTION
Before the change if I typed in say :lfoo.blod it would complain that foo.blod doesn't exist, rather than say it was an invalid command like it does in the Idris REPL