### PR TITLE
Chez shebang: use "scheme-script" instead of "scheme --script"

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -5,7 +5,7 @@ import System
 %default covering
 
 ttimpTests : List String
-ttimpTests 
+ttimpTests
     = ["test001", "test002", "test003", "test004", "test005",
        "test006", "test007", "test008", "test009",
        "case001",
@@ -21,7 +21,7 @@ blodwenTests
        "test021", "test022", "test023", "test024", "test025",
        "test026", "test027", "test028", "test029", "test030",
        "chez001", "chez002", "chez003", "chez004", "chez005",
-       "chez006",
+       "chez006", "chez007",
        "chicken001", "chicken002",
        "error001", "error002", "error003", "error004", "error005",
        "error006",
@@ -47,12 +47,12 @@ blodwenTests
        "with001"]
 
 chdir : String -> IO Bool
-chdir dir 
+chdir dir
     = do ok <- foreign FFI_C "chdir" (String -> IO Int) dir
          pure (ok == 0)
 
 fail : String -> IO ()
-fail err 
+fail err
     = do putStrLn err
          exitWith (ExitFailure 1)
 
@@ -82,4 +82,3 @@ main
          if (any not (ttimps ++ blods))
             then exitWith (ExitFailure 1)
             else exitWith ExitSuccess
-

--- a/tests/blodwen/chez007/expected
+++ b/tests/blodwen/chez007/expected
@@ -1,0 +1,6 @@
+hello blodwen devs
+1/1: Building hello (hello.blod)
+Welcome to Blodwen. Good luck.
+Main> Main> hello written
+Main> Bye for now!
+hello blodwen devs

--- a/tests/blodwen/chez007/hello.blod
+++ b/tests/blodwen/chez007/hello.blod
@@ -1,0 +1,2 @@
+main : IO ()
+main = putStrLn "hello blodwen devs"

--- a/tests/blodwen/chez007/input
+++ b/tests/blodwen/chez007/input
@@ -1,0 +1,3 @@
+:exec main
+:c hello main
+:q

--- a/tests/blodwen/chez007/run
+++ b/tests/blodwen/chez007/run
@@ -1,0 +1,4 @@
+$1 hello.blod < input
+./hello.ss
+rm -rf build hello.ss
+


### PR DESCRIPTION
The following shebang line doesn't work:

    #!/usr/bin/env scheme --script

It would work without the /usr/bin/env indirection, but whether env is
needed or not doing this instead consistently works:

    #!/usr/bin/env scheme-script

More context from the Chez User Guide:
http://cisco.github.io/ChezScheme/csug9.5/libraries.html#./libraries:h2