### PR TITLE
Add .gitattributes file for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.blod linguist-language=Idris


### PR DESCRIPTION
This adds a .gitattributes file so that syntax highlighting appears in `.blod` files present on github. (like https://github.com/vmchale/linear/blob/master/Logic/Linear.blod)