### PR TITLE
Escape backslashes in ${PREFIX} for Windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX = ${HOME}/.blodwen
+PREFIX = $(subst \,/,${HOME})/.blodwen
 export BLODWEN_PATH = ${CURDIR}/prelude/build:${CURDIR}/base/build
 export BLODWEN_DATA = ${CURDIR}/support
 


### PR DESCRIPTION
I still wasn't able to get the build working on my Windows box yet, even with this. However, it got me past a very early-on failure coming from:

    src/BlodwenPaths.idr:
    	echo 'module BlodwenPaths; export bprefix : String; bprefix = "${PREFIX}"' > src/BlodwenPaths.idr



